### PR TITLE
made the library fetchable

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    b.addModule("zeys", .{
+    _ = b.addModule("zeys", .{
         .root_source_file = b.path("src/zeys.zig"),
         .target = target,
         .optimize = optimize,

--- a/build.zig
+++ b/build.zig
@@ -2,18 +2,23 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
-    const optimise = b.standardOptimizeOption(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
     const lib = b.addStaticLibrary(.{
         .name = "zeys",
         .root_source_file = b.path("./src/zeys.zig"),
         .target = target,
-        .optimize = optimise,
+        .optimize = optimize,
+    });
+
+    b.addModule("zeys", .{
+        .root_source_file = b.path("src/zeys.zig"),
+        .target = target,
+        .optimize = optimize,
     });
 
     b.reference_trace = 10;
     lib.linkSystemLibrary("user32"); // building Windows lib
 
     b.installArtifact(lib);
-}   
-
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = "Zeys",
+    .version = "1.0.0",
+
+    .dependencies = .{},
+
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}


### PR DESCRIPTION
added a build.zig.zon and a module to the build.zig to be able to use `zig fetch` to use it as a library without copying the source code to a project. See https://github.com/SuSonicTH/zkey for an example usage.